### PR TITLE
Add Thumbnail to Media Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.0.10
+
+* Added Thumbnail as a Media Group property
+
 # 1.0.9
 
 * Correct README.md

--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -2,18 +2,21 @@ import 'package:rss_dart/domain/media/category.dart';
 import 'package:rss_dart/domain/media/content.dart';
 import 'package:rss_dart/domain/media/credit.dart';
 import 'package:rss_dart/domain/media/rating.dart';
+import 'package:rss_dart/domain/media/thumbnail.dart';
 import 'package:rss_dart/util/helpers.dart';
 import 'package:xml/xml.dart';
 
 class Group {
   final List<Content> contents;
   final List<Credit> credits;
+  final List<Thumbnail> thumbnails;
   final Category? category;
   final Rating? rating;
 
   const Group({
     this.contents = const <Content>[],
     this.credits = const <Credit>[],
+    this.thumbnails = const <Thumbnail>[],
     this.category,
     this.rating,
   });
@@ -30,6 +33,10 @@ class Group {
       credits: element
           .findElements('media:credit')
           .map((e) => Credit.parse(e))
+          .toList(),
+      thumbnails: element
+          .findElements('media:thumbnail')
+          .map((e) => Thumbnail.parse(e))
           .toList(),
       category: Category.parse(findElementOrNull(element, 'media:category')),
       rating: Rating.parse(findElementOrNull(element, 'media:rating')),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rss_dart
-version: 1.0.9
+version: 1.0.10
 description: rss_dart is a rss parser for RSS1.0/RSS2.0/Atom. This library is forked from webfeed https://github.com/witochandra/webfeed and dart_rss.
 homepage: https://github.com/ubuntu-flutter-community/rss.dart
 
@@ -13,4 +13,3 @@ dependencies:
 dev_dependencies:
   test: ^1.16.4
   pedantic: ^1.10.0
-

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -111,6 +111,12 @@ void main() {
     expect(item.media!.group!.category!.value, 'music/artist name/album/song');
     expect(item.media!.group!.rating!.value, 'nonadult');
 
+    final mediaGroupThumbnail = item.media!.group!.thumbnails.first;
+    expect(mediaGroupThumbnail.url, 'http://www.foo.com/keyframe1.jpg');
+    expect(mediaGroupThumbnail.width, '75');
+    expect(mediaGroupThumbnail.height, '50');
+    expect(mediaGroupThumbnail.time, '12:05:01.123');
+
     expect(item.media!.contents.length, 2);
     final mediaContent = item.media!.contents.first;
     expect(mediaContent.url, 'http://www.foo.com/video.mov');

--- a/test/xml/Atom-Media.xml
+++ b/test/xml/Atom-Media.xml
@@ -50,6 +50,7 @@
             <media:credit role="musician">band member 2</media:credit>
             <media:category>music/artist name/album/song</media:category>
             <media:rating>nonadult</media:rating>
+            <media:thumbnail url="http://www.foo.com/keyframe1.jpg" width="75" height="50" time="12:05:01.123" />
         </media:group>
         <media:title type="plain">The Judy's -- The Moo Song</media:title>
         <media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>


### PR DESCRIPTION
Requesting to add the Thumbnail property to the Media Group property.  As I was attempting to parse a Youtube Feed, I noticed the thumbnails are in the media group and not in the media.  I can't imagine I'm the only Youtube feed consumer to notice this issue.

References my issue: #2 