### PR TITLE
Add Description to Media Group

### DIFF
--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -3,6 +3,7 @@ import 'package:rss_dart/domain/media/content.dart';
 import 'package:rss_dart/domain/media/credit.dart';
 import 'package:rss_dart/domain/media/rating.dart';
 import 'package:rss_dart/domain/media/thumbnail.dart';
+import 'package:rss_dart/domain/media/description.dart';
 import 'package:rss_dart/util/helpers.dart';
 import 'package:xml/xml.dart';
 
@@ -12,6 +13,7 @@ class Group {
   final List<Thumbnail> thumbnails;
   final Category? category;
   final Rating? rating;
+  final Description? description;
 
   const Group({
     this.contents = const <Content>[],
@@ -19,12 +21,14 @@ class Group {
     this.thumbnails = const <Thumbnail>[],
     this.category,
     this.rating,
+    this.description,
   });
 
   static Group? parse(XmlElement? element) {
     if (element == null) {
       return null;
     }
+
     return Group(
       contents: element
           .findElements('media:content')
@@ -40,6 +44,9 @@ class Group {
           .toList(),
       category: Category.parse(findElementOrNull(element, 'media:category')),
       rating: Rating.parse(findElementOrNull(element, 'media:rating')),
+      description: Description.parse(
+        findElementOrNull(element, 'media:description'),
+      ),
     );
   }
 }

--- a/lib/util/helpers.dart
+++ b/lib/util/helpers.dart
@@ -8,7 +8,8 @@ XmlElement? findElementOrNull(
   String? namespace,
 }) {
   try {
-    return element.findAllElements(name, namespace: namespace).first;
+    return element.childElements
+        .firstWhere((child) => child.name.qualified == name);
   } on StateError {
     return null;
   }

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -117,6 +117,9 @@ void main() {
     expect(mediaGroupThumbnail.height, '50');
     expect(mediaGroupThumbnail.time, '12:05:01.123');
 
+    expect(item.media!.group!.description!.type, 'plain');
+    expect(item.media!.group!.description!.value, 'Some cool stuff!');
+
     expect(item.media!.contents.length, 2);
     final mediaContent = item.media!.contents.first;
     expect(mediaContent.url, 'http://www.foo.com/video.mov');

--- a/test/xml/Atom-Media.xml
+++ b/test/xml/Atom-Media.xml
@@ -51,6 +51,7 @@
             <media:category>music/artist name/album/song</media:category>
             <media:rating>nonadult</media:rating>
             <media:thumbnail url="http://www.foo.com/keyframe1.jpg" width="75" height="50" time="12:05:01.123" />
+            <media:description type="plain">Some cool stuff!</media:description>
         </media:group>
         <media:title type="plain">The Judy's -- The Moo Song</media:title>
         <media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>


### PR DESCRIPTION
Used by YouTube: https://www.youtube.com/feeds/videos.xml?channel_id=UClS6E2qjk2DkxRCZ1xU0VXA

Added test as well.

Alongside with this PR, I also change the helper `findElementOrNull` function. Originally it would search through all the element recursively, which doesn't work when `media:description` can be both child of `entry` and `media:group`. This new change should only find the first direct descendant as how it supposed to.